### PR TITLE
[FEATURE] Add configuration object for request middlewares

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
 		"phpstan/extension-installer": "^1.4",
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpunit/phpunit": "^10.5 || ^11.5 || ^12.1",
+		"psr/http-message": "^2.0",
+		"psr/http-server-handler": "^1.0",
+		"psr/http-server-middleware": "^1.0",
 		"shipmonk/composer-dependency-analyser": "^1.8"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2d02cbf9a57279bb7fcf568b8e6db88",
+    "content-hash": "16aeeb4f14d13a5aeb2b08110a25297c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/src/Configuration/MiddlewareConfiguration.php
+++ b/src/Configuration/MiddlewareConfiguration.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Configuration;
+
+use EliasHaeussler\Typo3ConfigObjects\ValueObject;
+
+/**
+ * MiddlewareConfiguration.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ *
+ * @phpstan-import-type MiddlewareOptions from ValueObject\RequestMiddleware
+ *
+ * @implements Configuration<array{
+ *     backend: array<string, MiddlewareOptions>,
+ *     frontend: array<string, MiddlewareOptions>,
+ * }>
+ */
+final class MiddlewareConfiguration implements Configuration
+{
+    /**
+     * @var list<ValueObject\RequestMiddleware>
+     */
+    private array $backendStack = [];
+
+    /**
+     * @var list<ValueObject\RequestMiddleware>
+     */
+    private array $frontendStack = [];
+
+    private function __construct() {}
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function addToBackendStack(ValueObject\RequestMiddleware ...$requestMiddlewares): self
+    {
+        foreach ($requestMiddlewares as $requestMiddleware) {
+            $this->backendStack[] = $requestMiddleware;
+        }
+
+        return $this;
+    }
+
+    public function addToFrontendStack(ValueObject\RequestMiddleware ...$requestMiddlewares): self
+    {
+        foreach ($requestMiddlewares as $requestMiddleware) {
+            $this->frontendStack[] = $requestMiddleware;
+        }
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $configuration = [
+            'backend' => [],
+            'frontend' => [],
+        ];
+
+        foreach ($this->backendStack as $requestMiddleware) {
+            $configuration['backend'][$requestMiddleware->name] = $requestMiddleware->toArray();
+        }
+
+        foreach ($this->frontendStack as $requestMiddleware) {
+            $configuration['frontend'][$requestMiddleware->name] = $requestMiddleware->toArray();
+        }
+
+        return $configuration;
+    }
+}

--- a/src/Exception/MiddlewareTargetIsMissing.php
+++ b/src/Exception/MiddlewareTargetIsMissing.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Exception;
+
+/**
+ * MiddlewareTargetIsMissing.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class MiddlewareTargetIsMissing extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'No middleware target is configured. Please set a target class or add configuration to an existing middleware.',
+            1744796822,
+        );
+    }
+}

--- a/src/ValueObject/RequestMiddleware.php
+++ b/src/ValueObject/RequestMiddleware.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\ValueObject;
+
+use EliasHaeussler\Typo3ConfigObjects\Contracts;
+use EliasHaeussler\Typo3ConfigObjects\Exception;
+use Psr\Http\Server;
+
+/**
+ * RequestMiddleware.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ *
+ * @phpstan-type MiddlewareOptions array{
+ *     target?: class-string<Server\MiddlewareInterface>,
+ *     disabled?: bool,
+ *     before?: list<non-empty-string>,
+ *     after?: list<non-empty-string>,
+ * }
+ *
+ * @implements Contracts\Arrayable<MiddlewareOptions>
+ */
+final class RequestMiddleware implements Contracts\Arrayable
+{
+    /**
+     * @var class-string<Server\MiddlewareInterface>|null
+     */
+    private ?string $target = null;
+    private ?bool $disabled = null;
+
+    /**
+     * @var array{before: list<non-empty-string>, after: list<non-empty-string>}
+     */
+    private array $dependencies = [
+        'before' => [],
+        'after' => [],
+    ];
+
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public readonly string $name,
+    ) {}
+
+    /**
+     * @param non-empty-string $name
+     */
+    public static function create(string $name): self
+    {
+        return new self($name);
+    }
+
+    /**
+     * @param class-string<Server\MiddlewareInterface> $target
+     */
+    public function setTarget(string $target): self
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    public function disable(): self
+    {
+        $this->disabled = true;
+
+        return $this;
+    }
+
+    public function enable(): self
+    {
+        $this->disabled = false;
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string ...$dependencies
+     */
+    public function before(string ...$dependencies): self
+    {
+        foreach ($dependencies as $dependency) {
+            $this->dependencies['before'][] = $dependency;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string ...$dependencies
+     */
+    public function after(string ...$dependencies): self
+    {
+        foreach ($dependencies as $dependency) {
+            $this->dependencies['after'][] = $dependency;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception\MiddlewareTargetIsMissing
+     */
+    public function toArray(): array
+    {
+        $this->validate();
+
+        $middlewareArray = [];
+
+        if (null !== $this->target) {
+            $middlewareArray['target'] = $this->target;
+        }
+        if (null !== $this->disabled) {
+            $middlewareArray['disabled'] = $this->disabled;
+        }
+        if ([] !== $this->dependencies['before']) {
+            $middlewareArray['before'] = $this->dependencies['before'];
+        }
+        if ([] !== $this->dependencies['after']) {
+            $middlewareArray['after'] = $this->dependencies['after'];
+        }
+
+        return $middlewareArray;
+    }
+
+    /**
+     * @throws Exception\MiddlewareTargetIsMissing
+     */
+    private function validate(): void
+    {
+        if (null === $this->target
+            && null === $this->disabled
+            && [] === $this->dependencies['before']
+            && [] === $this->dependencies['after']
+        ) {
+            throw new Exception\MiddlewareTargetIsMissing();
+        }
+    }
+}

--- a/tests/src/Configuration/MiddlewareConfigurationTest.php
+++ b/tests/src/Configuration/MiddlewareConfigurationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Tests\Configuration;
+
+use EliasHaeussler\Typo3ConfigObjects as Src;
+use EliasHaeussler\Typo3ConfigObjects\Tests;
+use PHPUnit\Framework;
+
+/**
+ * MiddlewareConfigurationTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Configuration\MiddlewareConfiguration::class)]
+final class MiddlewareConfigurationTest extends Framework\TestCase
+{
+    private Src\Configuration\MiddlewareConfiguration $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = Src\Configuration\MiddlewareConfiguration::create();
+    }
+
+    #[Framework\Attributes\Test]
+    public function addToBackendStackAppendsGivenRequestMiddlewaresToBackendStack(): void
+    {
+        $middlewareA = Src\ValueObject\RequestMiddleware::create('foo')
+            ->setTarget(Tests\Fixtures\DummyMiddleware::class)
+            ->before('baz')
+            ->after('boo')
+        ;
+        $middlewareB = Src\ValueObject\RequestMiddleware::create('baz')
+            ->disable()
+        ;
+
+        $this->subject->addToBackendStack($middlewareA, $middlewareB);
+
+        $expected = [
+            'backend' => [
+                'foo' => [
+                    'target' => Tests\Fixtures\DummyMiddleware::class,
+                    'before' => [
+                        'baz',
+                    ],
+                    'after' => [
+                        'boo',
+                    ],
+                ],
+                'baz' => [
+                    'disabled' => true,
+                ],
+            ],
+            'frontend' => [],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function addToFrontendStackAppendsGivenRequestMiddlewaresToFrontendStack(): void
+    {
+        $middlewareA = Src\ValueObject\RequestMiddleware::create('foo')
+            ->enable()
+        ;
+        $middlewareB = Src\ValueObject\RequestMiddleware::create('baz')
+            ->disable()
+        ;
+
+        $this->subject->addToFrontendStack($middlewareA, $middlewareB);
+
+        $expected = [
+            'backend' => [],
+            'frontend' => [
+                'foo' => [
+                    'disabled' => false,
+                ],
+                'baz' => [
+                    'disabled' => true,
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+}

--- a/tests/src/Exception/MiddlewareTargetIsMissingTest.php
+++ b/tests/src/Exception/MiddlewareTargetIsMissingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Tests\Exception;
+
+use EliasHaeussler\Typo3ConfigObjects as Src;
+use PHPUnit\Framework;
+
+/**
+ * MiddlewareTargetIsMissingTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\MiddlewareTargetIsMissing::class)]
+final class MiddlewareTargetIsMissingTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function constructorReturnsExceptionForTargetOption(): void
+    {
+        $actual = new Src\Exception\MiddlewareTargetIsMissing();
+
+        self::assertSame(
+            'No middleware target is configured. Please set a target class or add configuration to an existing middleware.',
+            $actual->getMessage(),
+        );
+        self::assertSame(1744796822, $actual->getCode());
+    }
+}

--- a/tests/src/Fixtures/DummyMiddleware.php
+++ b/tests/src/Fixtures/DummyMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Tests\Fixtures;
+
+use Psr\Http\Message;
+use Psr\Http\Server;
+
+/**
+ * DummyMiddleware.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class DummyMiddleware implements Server\MiddlewareInterface
+{
+    public function process(
+        Message\ServerRequestInterface $request,
+        Server\RequestHandlerInterface $handler,
+    ): Message\ResponseInterface {
+        return $handler->handle($request);
+    }
+}

--- a/tests/src/ValueObject/RequestMiddlewareTest.php
+++ b/tests/src/ValueObject/RequestMiddlewareTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-config-objects".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3ConfigObjects\Tests\ValueObject;
+
+use EliasHaeussler\Typo3ConfigObjects as Src;
+use EliasHaeussler\Typo3ConfigObjects\Tests;
+use PHPUnit\Framework;
+
+/**
+ * RequestMiddlewareTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\ValueObject\RequestMiddleware::class)]
+final class RequestMiddlewareTest extends Framework\TestCase
+{
+    private Src\ValueObject\RequestMiddleware $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = Src\ValueObject\RequestMiddleware::create('foo');
+    }
+
+    #[Framework\Attributes\Test]
+    public function setTargetConfiguresGivenTarget(): void
+    {
+        $this->subject->setTarget(Tests\Fixtures\DummyMiddleware::class);
+
+        $expected = [
+            'target' => Tests\Fixtures\DummyMiddleware::class,
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function disableSetsDisabledOptionToTrue(): void
+    {
+        $this->subject->disable();
+
+        $expected = [
+            'disabled' => true,
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function enableSetsDisabledOptionToFalse(): void
+    {
+        $this->subject->enable();
+
+        $expected = [
+            'disabled' => false,
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function beforeAddsDependencies(): void
+    {
+        $this->subject->before('baz', 'boo');
+
+        $expected = [
+            'before' => [
+                'baz',
+                'boo',
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function afterAddsDependencies(): void
+    {
+        $this->subject->after('baz', 'boo');
+
+        $expected = [
+            'after' => [
+                'baz',
+                'boo',
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function toArrayThrowsExceptionIfTargetIsMissingAndMiddlewareIsNotFurtherConfigured(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\MiddlewareTargetIsMissing(),
+        );
+
+        $this->subject->toArray();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new middleware configuration system for the `eliashaeussler/typo3-config-objects` Composer package. The changes include adding a new dependency, creating a `MiddlewareConfiguration` class, and defining a `RequestMiddleware` value object.

Key changes:

### Dependency Management:
* Added `psr/http-server-middleware` as a new dependency in the `composer.json` file.

### Middleware Configuration:
* Created a new `MiddlewareConfiguration` class in `src/Configuration/MiddlewareConfiguration.php` to manage backend and frontend middleware stacks. This class includes methods to add middleware to the stacks and convert the configuration to an array.

### Value Objects:
* Implemented a `RequestMiddleware` value object in `src/ValueObject/RequestMiddleware.php`. This class includes properties and methods to manage middleware attributes such as name, target, dependencies, and state (enabled/disabled).